### PR TITLE
Remove ez_setup.py

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include README CHANGES *.py
+recursive-include schemasync *.py


### PR DESCRIPTION
Building from the release archive is broken because ez_setup.py is missing. 

There are two options: include ez_setup.py in the archive or remove the dependency. But, it is probably safe to assume that anyone has setuptools installed so just remove the requirement,
