### PR TITLE
Separating ALTER TABLE actions

### DIFF
--- a/schemasync/syncdb.py
+++ b/schemasync/syncdb.py
@@ -47,9 +47,15 @@ def sync_schema(fromdb, todb, options):
             rlist.append(r)
 
         if plist and rlist:
-            p = "%s %s;" % (to_table.alter(), ', '.join(plist))
-            r = "%s %s;" % (to_table.alter(), ', '.join(rlist))
-            yield p, r
+            p = []
+            for eachp in plist:
+                p.append("%s %s;" % (to_table.alter(), eachp))
+            
+            r = []
+            for eachr in rlist:
+                r.append("%s %s;" % (to_table.alter(), eachr))
+        
+        yield '\n'.join(p), '\n'.join(r)
 
 
 def sync_table(from_table, to_table, options):


### PR DESCRIPTION
Modified syncdb.py to make a unique action per ALTER TABLE, there are an MySQL bug when you try to modify a column (X) which have referenced to another column (Y), and lately modified the same column (Y), it raises an error (1054)
