### PR TITLE
Fix mysql version comparison logic. Fix typo.

### DIFF
--- a/schemasync/schemasync.py
+++ b/schemasync/schemasync.py
@@ -189,12 +189,12 @@ def app(sourcedb='', targetdb='', version_filename=False,
     source_obj = schemaobject.SchemaObject(sourcedb)
     target_obj = schemaobject.SchemaObject(targetdb)
 
-    if source_obj.version < '5.0.0':
+    if utils.compare_version(source_obj.version, '5.0.0') < 0:
         logging.error("%s requires MySQL version 5.0+ (source is v%s)"
                         % (APPLICATION_NAME, source_obj.version))
         return 1
 
-    if target_obj.version < '5.0.0':
+    if  utils.compare_version(target_obj.version, '5.0.0') < 0:
         logging.error("%s requires MySQL version 5.0+ (target is v%s)"
                 % (APPLICATION_NAME, target_obj.version))
         return 1

--- a/schemasync/utils.py
+++ b/schemasync/utils.py
@@ -48,7 +48,7 @@ def create_pnames(db, tag=None, date_format="%Y%m%d"):
        Filename format: <db>[_<tag>].<date=DATE_FORMAT>.(patch|revert).sql
 
         Args:
-            db: srting, databse name
+            db: string, database name
             tag: string, optional, tag for the filenames
             date_format: string, the current date format
                          Default Format: 21092009

--- a/schemasync/utils.py
+++ b/schemasync/utils.py
@@ -66,6 +66,25 @@ def create_pnames(db, tag=None, date_format="%Y%m%d"):
     return ("%s.%s" % (basename, "patch.sql"),
             "%s.%s" % (basename, "revert.sql"))
 
+def compare_version(x, y, separator = r'[.-]'):
+    """Return negative if version x<y, zero if x==y, positive if x>y.
+
+        Args:
+            x: string, version x to compare
+            y: string, version y to compare
+
+        Returns:
+            integer representing the compare result of version x and y.
+    """
+    x_array = re.split(separator, x)
+    y_array = re.split(separator, y)
+    for index in range(min(len(x_array),len(y_array))):
+        if x_array[index] != y_array[index]:
+            try:
+                return cmp(int(x_array[index]), int(y_array[index]))
+            except ValueError:
+                return 0
+    return 0
 
 class PatchBuffer(object):
     """Class for creating patch files

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,7 +3,7 @@ import unittest
 import os
 import glob
 import datetime
-from schemasync.utils import versioned, create_pnames, PatchBuffer
+from schemasync.utils import versioned, create_pnames, compare_version, PatchBuffer
 
 
 class TestVersioned(unittest.TestCase):
@@ -82,6 +82,13 @@ class TestPNames(unittest.TestCase):
         r = "mydb_my-tag_123.%s.revert.sql" % d
         self.assertEqual((p,r), create_pnames("mydb",tag="my-tag_123", date_format="%Y%m%d"))
 
+class TestCompareVersion(unittest.TestCase):
+    def test_basic_compare(self):
+        self.assertTrue(compare_version('10.0.0-mysql', '5.0.0-mysql') > 0)
+        self.assertTrue(compare_version('10.0.0-mysql', '5.0.0-log') > 0)
+        self.assertTrue(compare_version('5.1.0-mysql', '5.0.1-log') > 0)
+        self.assertTrue(compare_version('5.0.0-mysql', '5.0.0-log') == 0)
+        self.assertTrue(compare_version('5.0.0-mysql', '5.0.1-log') < 0)
 
 class TestPatchBuffer(unittest.TestCase):
 


### PR DESCRIPTION
## Fix mysql version comparison logic:

In python, string comparison considers "10.0.0" < "9.0.0".

So a mysql instance with version "10.0.0-mysql" will be rejected with error:

> ... requires MySQL version 5.0+ ...

To fix that, I added `compare_version()` to replace the old string comparison:
`compare_version(x, y)` returns a positive integer when version x is newer than version y, where version x and y are in the format: "major.minor.build-name", as in "5.6.0-mysql"
