### PR TITLE
SchemaObject 0.5.7 requires PyMySQL, not MySQLdb

### DIFF
--- a/README
+++ b/README
@@ -56,8 +56,8 @@ Prerequisites
 * To run Schema Sync, you need to have:
     - Python 2.4, 2.5, or 2.6
     - MySQL <http://www.mysql.com/>, version 5.0 or higher
-    - MySQLdb <http://sourceforge.net/projects/mysql-python>, version 1.2.1p2 or higher
-    - SchemaObject <http://matuson.com/code/schemaobject> 0.5.7 or higher
+    - PyMySQL <https://github.com/PyMySQL/PyMySQL>, version 0.6.2 or higher
+    - SchemaObject <https://github.com/mmatuson/SchemaObject> 0.5.7 or higher
 * To run the test suite, you need to install a copy of the Sakila Database <http://dev.mysql.com/doc/sakila/en/index.html>, version 0.8
 
 Standard Installation

--- a/schemasync/schemasync.py
+++ b/schemasync/schemasync.py
@@ -25,9 +25,9 @@ __license__ = "Apache 2.0"
 warnings.simplefilter("ignore", DeprecationWarning)
 
 try:
-    import MySQLdb
-except ImportError:
-    print "Error: Missing Required Dependency MySQLdb."
+    import pymysql
+except ImportErrorPyMySQL:
+    print "Error: Missing Required Dependency PyMySQL."
     sys.exit(1)
 
 try:


### PR DESCRIPTION
Modern versions of SchemaObject have migrated from MySQLdb to PyMySQL.