### PR TITLE
Fix setup/imports

### DIFF
--- a/schemasync/schemasync.py
+++ b/schemasync/schemasync.py
@@ -6,8 +6,8 @@ import os
 import logging
 import datetime
 import optparse
-import syncdb
-import utils
+from schemasync import syncdb
+from schemasync import utils
 import warnings
 
 __author__ = """

--- a/schemasync/schemasync.py
+++ b/schemasync/schemasync.py
@@ -18,7 +18,7 @@ __copyright__ = """
 Copyright 2009-2016 Mitch Matuson
 Copyright 2016 Mustafa Ozgur
 """
-__version__ = "0.9.7"
+__version__ = "0.9.8"
 __license__ = "Apache 2.0"
 
 # supress MySQLdb DeprecationWarning in Python 2.6

--- a/schemasync/syncdb.py
+++ b/schemasync/syncdb.py
@@ -1,4 +1,4 @@
-from utils import REGEX_TABLE_AUTO_INC, REGEX_TABLE_COMMENT
+from schemasync.utils import REGEX_TABLE_AUTO_INC, REGEX_TABLE_COMMENT
 
 
 def sync_schema(fromdb, todb, options):

--- a/schemasync/utils.py
+++ b/schemasync/utils.py
@@ -87,7 +87,9 @@ def compare_version(x, y, separator=r'[.-]'):
     for index in range(min(len(x_array), len(y_array))):
         if x_array[index] != y_array[index]:
             try:
-                return cmp(int(x_array[index]), int(y_array[index]))
+                a = int(x_array[index])
+                b = int(y_array[index])
+                return (a > b) - (a < b)
             except ValueError:
                 return 0
     return 0

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python
-import ez_setup
+try:
+    import setuptools
+except ImportError:
+    import ez_setup
+    ez_setup.use_setuptools()
+    import setuptools
 
-ez_setup.use_setuptools()
-
-from setuptools import setup
-
-setup(
+setuptools.setup(
     name='SchemaSync',
     version='0.9.7',
     description='A MySQL Schema Synchronization Utility',

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ except ImportError:
 
 setuptools.setup(
     name='SchemaSync',
-    version='0.9.7',
+    version='0.9.8',
     description='A MySQL Schema Synchronization Utility',
     author='Mitch Matuson, Mustafa Ozgur',
     packages=['schemasync'],


### PR DESCRIPTION
When using with pipx (which is recommended for Debian) relative `import X` statements for relative modules don't work. I don't know why, I don't care enough to find out, but using the parent name seems to fix it.

Could you please also make a release to [pypi](https://pypi.org/project/SchemaSync/#history)? Currently the most recent version listed there is from nearly 5 years ago, and is utterly broken on newer Python.